### PR TITLE
Cleanup & Kein MESH5 wenn kein dual wifi

### DIFF
--- a/files/etc/config/fastd
+++ b/files/etc/config/fastd
@@ -1,7 +1,6 @@
 package fastd
 
 config fastd mesh_vpn
-
     option enabled 1
 
     list config '/etc/fastd/fastd.conf'

--- a/files/etc/config/firewall
+++ b/files/etc/config/firewall
@@ -5,27 +5,26 @@ config defaults
     option forward      REJECT
 
 config zone
-    option name     wan
+    option name         wan
     option network      'wan'
     option input        ACCEPT
     option output       ACCEPT
     option forward      REJECT
 
 config zone
-    option name     freifunk
+    option name         freifunk
     option network      'freifunk'
     option input        ACCEPT
     option output       ACCEPT
     option forward      REJECT
 
 config rule
-    option name             Reject-Telnet
-    option src      *
-    option proto            tcp
-    option dest_port        23
-    option target           REJECT
+    option name         Reject-Telnet
+    option src          *
+    option proto        tcp
+    option dest_port    23
+    option target       REJECT
 
 # include a file with users custom iptables rules
 config include
     option path /etc/firewall.user
-

--- a/files/etc/fastd/backbone/gw01
+++ b/files/etc/fastd/backbone/gw01
@@ -1,3 +1,2 @@
 key "6966dd5a0da9107ef9b08edeeb410b4f4e5542dd83042a53210dbd8709c46a4e";
 remote ipv4 "gw01.freifunk-rhein-neckar.de" port 10000;
-

--- a/files/etc/fastd/backbone/gw02
+++ b/files/etc/fastd/backbone/gw02
@@ -1,3 +1,2 @@
 key "0fdf2eb0707a1fefbc3f73359601db1f6f549cee1f5d9c454ccf0590c956771b";
 remote ipv4 "gw02.freifunk-rhein-neckar.de" port 10000;
-

--- a/files/etc/fastd/backbone/gw03
+++ b/files/etc/fastd/backbone/gw03
@@ -1,3 +1,2 @@
 key "5c22137952681ca821d6f9dc711ca1cb94c6ff2b0e46a2aa6c9e90f338fa5593";
 remote ipv4 "gw03.freifunk-rhein-neckar.de" port 10000;
-

--- a/files/etc/fastd/backbone/gw04
+++ b/files/etc/fastd/backbone/gw04
@@ -1,3 +1,2 @@
 key "8be4613b63b063fdd6606e02279cac497bf286dd4d31ea0bf886b49ee539802e";
 remote ipv4 "gw04.freifunk-rhein-neckar.de" port 10000;
-

--- a/files/etc/fastd/backbone/gw05
+++ b/files/etc/fastd/backbone/gw05
@@ -1,3 +1,2 @@
 key "313f8733fdb3de152c6dfe520a3c70d6cf37a94c7727a7530e6a491ac3920a59";
 remote ipv4 "gw05.freifunk-rhein-neckar.de" port 10000;
-

--- a/files/etc/fastd/backbone/gw06
+++ b/files/etc/fastd/backbone/gw06
@@ -1,3 +1,2 @@
 key "2f4770397d2cf1533dcd0ab817d73bad933760c1367d5c85d1367bfbdefc78fd";
 remote ipv4 "gw06.freifunk-rhein-neckar.de" port 10000;
-

--- a/files/etc/fastd/backbone/gw07
+++ b/files/etc/fastd/backbone/gw07
@@ -1,3 +1,2 @@
 key "7a6fe61ac6b22707c7a6d004f6fcef9c8a1541872dd73998aa53677b2e788121";
 remote ipv4 "gw07.freifunk-rhein-neckar.de" port 10000;
-

--- a/files/etc/fastd/backbone/gw08
+++ b/files/etc/fastd/backbone/gw08
@@ -1,3 +1,2 @@
 key "81813900a53dc6483114e804de8b463799da4cda52393eb454a8d15cdacbf289";
 remote ipv4 "gw08.freifunk-rhein-neckar.de" port 10000;
-

--- a/files/etc/fastd/backbone/gw09
+++ b/files/etc/fastd/backbone/gw09
@@ -1,3 +1,2 @@
 key "743e20f293de1a00a82b34d64e62363b3c4069ae20051f9847c70c8d2d885207";
 remote ipv4 "gw09.freifunk-rhein-neckar.de" port 10000;
-

--- a/files/etc/fastd/backbone/gw10
+++ b/files/etc/fastd/backbone/gw10
@@ -1,3 +1,2 @@
 key "1937cb72cea3c4bef0bbdb84e0c1d7692580160e0a55d03cb4c1ca670339fc0d";
 remote ipv4 "gw10.freifunk-rhein-neckar.de" port 10000;
-

--- a/files/etc/init.d/ebtables-firewall
+++ b/files/etc/init.d/ebtables-firewall
@@ -14,7 +14,6 @@
 # Removing a specific rule file:
 # $ ./firewall-ebtables stop /lib/freifunk/ebtables/100-mcast-chain
 
-
 START=19
 STOP=91
 RULES_DIR='/lib/freifunk/ebtables'
@@ -44,7 +43,6 @@ exec_all() {
     done
     IFS="$old_ifs"
 }
-
 
 start() {
     (

--- a/files/etc/uci-defaults/zzz-freifunk-upgrade
+++ b/files/etc/uci-defaults/zzz-freifunk-upgrade
@@ -1,30 +1,24 @@
 #!/bin/sh
 
-
-
 VERSION_FILE=/etc/freifunk_version
 
 KEEP_VERSION_FILE=/etc/.freifunk_version_keep
 
 UPGRADE_DIR=/lib/freifunk/upgrade
 
-
 newer_than() {
 	local old="$(printf '%s\n%s\n' "$1" "$2" | sort -n | head -n 1)"
 	test "$1" != "$old"
 }
-
 
 do_dir() {
 	local s
 	for s in "$1"/*; do "$s"; done
 }
 
-
 version="$(cat "$VERSION_FILE")"
 
-oldversion="$(cat "$KEEP_VERSION_FILE" 2>/dev/null)"
-
+oldversion="$(cat "$KEEP_VERSION_FILE" 2> /dev/null)"
 
 (
 	cd "$UPGRADE_DIR"
@@ -45,4 +39,3 @@ oldversion="$(cat "$KEEP_VERSION_FILE" 2>/dev/null)"
 )
 
 echo "$version" > "$KEEP_VERSION_FILE"
-

--- a/files/lib/freifunk/ebtables/110-mcast-allow-spotify
+++ b/files/lib/freifunk/ebtables/110-mcast-allow-spotify
@@ -1,3 +1,2 @@
 rule MULTICAST_OUT -p IPv4 --ip-destination 239.192.83.80 -j RETURN
 rule MULTICAST_OUT -p IPv4 --ip-destination 239.255.255.250 -j RETURN
-

--- a/files/lib/freifunk/lib_node.sh
+++ b/files/lib/freifunk/lib_node.sh
@@ -3,28 +3,28 @@
 
 # Hardware-Address according to sticker
 get_main_address() {
-    if is_dual_wifi;then
-    	get_radio_address "wlan1"
+    if is_dual_wifi; then
+        get_radio_address "wlan1"
     else
-	get_radio_address "wlan0"
+        get_radio_address "wlan0"
     fi
 }
 
-get_radio_address(){
-	ifconfig $1 | grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}' | awk '{print tolower($0)}'
+get_radio_address() {
+    ip l sh $1 | awk '/ether/ {print $2}'
 }
 
 
 # Node_Id = HW-Address, alphanumeric
-get_node_id(){
-	macaddr=$(get_main_address)
-        echo ${macaddr//:/}
+get_node_id() {
+    macaddr=$(get_main_address)
+    echo ${macaddr//:/}
 }
 
 # Dual wifi? yes / no
 # More than two devies => dual wifi, too.
 # UNDEFINED, IF WIFI IS PRESENT!
-is_dual_wifi(){
-  inum=$(iw phy | grep Wiphy | wc -l)
-  test "$inum" != "1"
+is_dual_wifi() {
+    inum=$(iw phy | grep -c Wiphy)
+    test "$inum" != "1"
 }

--- a/files/lib/freifunk/upgrade/2.0/12wireless
+++ b/files/lib/freifunk/upgrade/2.0/12wireless
@@ -3,7 +3,7 @@
 
 uci set wireless.radio0.channel='6'
 
-# set mash wifi multicast rate
+# set mesh wifi multicast rate
 uci set wireless.wifi_mesh.mcast_rate='12000'
 uci set wireless.wifi_mesh5.mcast_rate='12000'
 

--- a/files/lib/freifunk/upgrade/2.0/12wireless
+++ b/files/lib/freifunk/upgrade/2.0/12wireless
@@ -5,7 +5,10 @@ uci set wireless.radio0.channel='6'
 
 # set mesh wifi multicast rate
 uci set wireless.wifi_mesh.mcast_rate='12000'
-uci set wireless.wifi_mesh5.mcast_rate='12000'
+
+if is_dual_wifi; then
+    uci set wireless.wifi_mesh5.mcast_rate='12000'
+fi
 
 uci commit wireless
 

--- a/files/lib/freifunk/upgrade/initial/10system
+++ b/files/lib/freifunk/upgrade/initial/10system
@@ -1,5 +1,4 @@
 #!/bin/sh
-
 . /lib/ar71xx.sh
 . /lib/freifunk/lib_node.sh
 
@@ -9,32 +8,32 @@ case "$board" in
 tl-wdr3600|\
 tl-wdr4300)
     uci -q batch <<EOF
-        set system.led_wlan2g.trigger='netdev'
-        set system.led_wlan2g.dev='wlan0'
-        set system.led_wlan2g.mode='link'
+set system.led_wlan2g.trigger='netdev'
+set system.led_wlan2g.dev='wlan0'
+set system.led_wlan2g.mode='link'
 
-        set system.led_wlan5='led'
-        set system.led_wlan5.name='WLAN5'
-        set system.led_wlan5.sysfs='ath9k-phy1'
-        set system.led_wlan5.trigger='netdev'
-        set system.led_wlan5.dev='wlan1'
-        set system.led_wlan5.mode='link'
+set system.led_wlan5='led'
+set system.led_wlan5.name='WLAN5'
+set system.led_wlan5.sysfs='ath9k-phy1'
+set system.led_wlan5.trigger='netdev'
+set system.led_wlan5.dev='wlan1'
+set system.led_wlan5.mode='link'
 EOF
     ;;
 *)
     uci -q batch <<EOF
-        set system.led_wlan.trigger='netdev'
-        set system.led_wlan.dev='wlan0'
-        set system.led_wlan.mode='link'
+set system.led_wlan.trigger='netdev'
+set system.led_wlan.dev='wlan0'
+set system.led_wlan.mode='link'
 EOF
     ;;
 esac
 
 
 uci -q batch <<EOF
-#    set system.@system[0].hostname="$(get_node_id)"
-    set system.@system[0].timezone='CET-1CEST,M3.5.0,M10.5.0/3'
-#    set freifunk.@node[0].nodeid="$(get_node_id)"
-    commit system
-    commit freifunk
+# set system.@system[0].hostname="$(get_node_id)"
+set system.@system[0].timezone='CET-1CEST,M3.5.0,M10.5.0/3'
+# set freifunk.@node[0].nodeid="$(get_node_id)"
+commit system
+# commit freifunk
 EOF

--- a/files/lib/freifunk/upgrade/initial/11network
+++ b/files/lib/freifunk/upgrade/initial/11network
@@ -1,5 +1,4 @@
 #!/bin/sh
-
 . /lib/ar71xx.sh
 . /lib/freifunk/lib_node.sh
 
@@ -29,10 +28,10 @@ EOF
 # Falls kein WAN-Interface vorhanden, nutze einziges LAN-Interface
 if [ -z "$wan_ifname" ]
 then
-        uci set network.freifunk.ifname="bat0"
-        uci set network.wan.ifname="$lan_ifname"
+    uci set network.freifunk.ifname="bat0"
+    uci set network.wan.ifname="$lan_ifname"
 else
-        uci set network.freifunk.ifname="$lan_ifname bat0"
+    uci set network.freifunk.ifname="$lan_ifname bat0"
 fi
 
 uci -q batch <<EOF
@@ -55,9 +54,7 @@ set network.mesh_vpn='interface'
 set network.mesh_vpn.ifname='mesh-vpn'
 set network.mesh_vpn.proto='batadv'
 set network.mesh_vpn.mesh='bat0'
-
 EOF
-
 
 local mainaddr=$(get_main_address)
 local oIFS="$IFS"; IFS=":"; set -- $mainaddr; IFS="$oIFS"
@@ -67,6 +64,5 @@ local vpnaddr=$(printf "%02x:%s:%s:%02x:%s:%s" $(( 0x$1 | $b2mask )) $2 $3 $(( (
 
 uci set network.freifunk.macaddr="$mainaddr"
 uci set network.mesh_vpn.macaddr="$vpnaddr"
-
 
 uci commit network

--- a/files/lib/freifunk/upgrade/initial/11network
+++ b/files/lib/freifunk/upgrade/initial/11network
@@ -45,16 +45,20 @@ set network.mesh0.proto='batadv'
 set network.mesh0.mtu='1528'
 set network.mesh0.mesh='bat0'
 
-set network.mesh5='interface'
-set network.mesh5.proto='batadv'
-set network.mesh5.mtu='1528'
-set network.mesh5.mesh='bat0'
-
 set network.mesh_vpn='interface'
 set network.mesh_vpn.ifname='mesh-vpn'
 set network.mesh_vpn.proto='batadv'
 set network.mesh_vpn.mesh='bat0'
 EOF
+
+if is_dual_wifi; then
+    uci -q batch <<EOF
+set network.mesh5='interface'
+set network.mesh5.proto='batadv'
+set network.mesh5.mtu='1528'
+set network.mesh5.mesh='bat0'
+EOF
+fi
 
 local mainaddr=$(get_main_address)
 local oIFS="$IFS"; IFS=":"; set -- $mainaddr; IFS="$oIFS"

--- a/files/lib/freifunk/upgrade/initial/12wireless
+++ b/files/lib/freifunk/upgrade/initial/12wireless
@@ -27,7 +27,7 @@ set wireless.wifi_mesh.mcast_rate='12000'
 EOF
 
 if is_dual_wifi; then
-uci -q batch <<EOF
+    uci -q batch <<EOF
 delete wireless.radio1.disabled
 delete wireless.@wifi-iface[0]
 set wireless.radio1.channel='44'

--- a/files/lib/freifunk/upgrade/initial/12wireless
+++ b/files/lib/freifunk/upgrade/initial/12wireless
@@ -1,7 +1,6 @@
 #!/bin/sh
 . /lib/freifunk/lib_node.sh
 
-
 # If the device has to wifi, wifi 2 has to be set up as well ..
 uci -q batch <<EOF
 delete wireless.radio0.disabled
@@ -25,11 +24,9 @@ set wireless.wifi_mesh.mode='adhoc'
 set wireless.wifi_mesh.ssid='mesh'
 set wireless.wifi_mesh.bssid='02:BA:00:00:00:01'
 set wireless.wifi_mesh.mcast_rate='12000'
-commit wireless
 EOF
 
-
-if is_dual_wifi ;then
+if is_dual_wifi; then
 uci -q batch <<EOF
 delete wireless.radio1.disabled
 delete wireless.@wifi-iface[0]
@@ -48,7 +45,8 @@ set wireless.wifi_mesh5.mode='adhoc'
 set wireless.wifi_mesh5.ssid='mesh'
 set wireless.wifi_mesh5.bssid='02:BA:00:00:00:02'
 set wireless.wifi_mesh5.mcast_rate='12000'
-#set batman-adv.bat0.interfaces='mesh-vpn mesh0 mesh5'
-commit
+# set batman-adv.bat0.interfaces='mesh-vpn mesh0 mesh5'
 EOF
 fi
+
+uci commit wireless

--- a/files/lib/freifunk/upgrade/initial/13fastd
+++ b/files/lib/freifunk/upgrade/initial/13fastd
@@ -2,7 +2,8 @@
 
 KEY=`fastd --generate-key --machine-readable`
 uci -q batch <<EOF
-    set fastd.mesh_vpn.enabled=1
-    set fastd.mesh_vpn.secret="$KEY"
+set fastd.mesh_vpn.enabled=1
+set fastd.mesh_vpn.secret="$KEY"
 EOF
+
 uci commit fastd


### PR DESCRIPTION
* Einheitliche Formatierung
* lib_node.sh:
       * get_radio_address # ifconfig -> ip l sh (ist kürzer und wer weiß wie lange es ifconfig noch gibt ;)
       * is_dual_wifi # Direkt mit grep -c zählen
* MESH5 Interface wurde auch erstellt, wenn kein 5 Ghz verfügbar war